### PR TITLE
Added unsubscribe and monitoring of subscribers to auto-unsubscribe on crash

### DIFF
--- a/apps/exile/lib/exile/store/ets.ex
+++ b/apps/exile/lib/exile/store/ets.ex
@@ -33,8 +33,8 @@ defmodule Exile.Store.ETS do
   end
 
   @impl Exile.Store
-  def unsubscribe(_path, _subscriber) do
-    :not_implemented
+  def unsubscribe(path, subscriber) do
+    Table.unsubscribe(path, subscriber)
   end
 
   @impl Exile.Store

--- a/apps/exile/lib/exile/store/ets/registry.ex
+++ b/apps/exile/lib/exile/store/ets/registry.ex
@@ -7,7 +7,7 @@ defmodule Exile.Store.ETS.Table.Registry do
     end
   end
 
-  @doc "Reference used to access process."
+  @typedoc "Reference used to access process."
   @type ref :: String.t()
 
   @doc "Child Specification for `#{__MODULE__}`"


### PR DESCRIPTION
Implements the following: 

* unsubscribe
* auto-unsubscribe on subscriber crash

```elixir
  describe "unsubscribe" do
    test "should unsubscribe to change events on record" do
      subscriber =
        Task.async(fn ->
          receive do
            msg -> msg
          after
            100 ->
              :no_message_received
          end
        end)

      :ok = Exile.subscribe("posts", subscriber.pid)

      :ok = Exile.unsubscribe("posts", subscriber.pid)

      json = """
      {
        "author": "holsee",
        "tags": ["bill", "ted", "rufus", "beethoven"],
        "comments": []
      }
      """

      post = Jason.decode!(json)
      path = "posts"
      assert {:ok, post_id} = Exile.post(path, post)

      assert :no_message_received = Task.await(subscriber)
    after
      Exile.delete("posts")
    end
  end
```

```elixir
iex(1)> subscriber =
...(1)>   Task.async(fn ->
...(1)>     receive do
...(1)>       msg -> msg
...(1)>     end
...(1)>   end)
%Task{
  owner: #PID<0.362.0>,
  pid: #PID<0.369.0>,
  ref: #Reference<0.3332852052.2503475205.248614>
}
iex(2)>
nil
iex(3)> :ok = Exile.subscribe("posts", subscriber.pid)
[debug] [Elixir.Exile.Store.ETS.Table] [INIT] New Table created @ posts
:ok
iex(4)> :ok = Exile.subscribe("foos", subscriber.pid)
[debug] [Elixir.Exile.Store.ETS.Table] [INIT] New Table created @ foos
:ok
iex(5)> Process.exit(subscriber.pid, :brutal_kill)
[debug] [Elixir.Exile.Store.ETS.Table] [SUBSCRIPTION] Subscriber down #PID<0.369.0>, removing subscription.
[debug] [Elixir.Exile.Store.ETS.Table] [SUBSCRIPTION] Subscriber down #PID<0.369.0>, removing subscription.
```